### PR TITLE
Add additional Irish exceptions

### DIFF
--- a/__tests__/nameCase.spec.ts
+++ b/__tests__/nameCase.spec.ts
@@ -23,6 +23,7 @@ describe('Environment', () => {
       "Mackle", "Macklin", "Mackie",
       "Macquarie", "Machado", "Macevicius",
       "Maciulis", "Macias", "MacMurdo",
+      "MacKrine", "MacHira" "MacHocho",
   
       // Roman numerals
       "Henry VIII", "Louis III", "Louis XIV",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,9 @@ class Environment {
     [/\bMacKley/, 'Mackley'],
     [/\bMacHell/, 'Machell'],
     [/\bMacHon/, 'Machon'],
+    [/\bMacKrine/, 'Mackrine'],
+    [/\bMacHira/, 'Machira'],
+    [/\bMacHocho/, 'Machocho']
   ]
 
   // General replacements.


### PR DESCRIPTION
Hi,

Working with Kenyan names I noticed `Mackrine`, `Machira` and `Machocho` ended-up incorrectly captialized.

I think this should help?